### PR TITLE
Variable values are read from .tfvars

### DIFF
--- a/.tfvars.sample
+++ b/.tfvars.sample
@@ -1,0 +1,108 @@
+######## This is a sample file. Copy to a file named .tfvars and edit values for your environment.
+
+######## EDIT THESE ITEMS
+
+# Determines if Columnstore LocalStorage or S3 Topology
+use_s3 = true
+
+# Grab your enterprise token from the MariaDB website (https://customers.mariadb.com/downloads/token/)
+mariadb_enterprise_token = "YOUR MARIADB ENTERPRISE TOKEN HERE"
+
+# Create a random string for the columnstore API key
+cmapi_key = "CREATE A COLUMNSTORE API KEY HERE - ANY RANDOM STRING"
+
+# Set a password for the PCS cluster
+pcs_pass = "SET PCS CLUSTER PASSWORD HERE - ANY RANDOM STRING"
+
+######## DATABASE CREDENTIALS
+
+# MariaDB admin credentials
+admin_user = "CHOOSE A MARIADB ADMIN USERNAME HERE"
+admin_pass = "SET YOUR MARIADB ADMIN USER PASSWORD HERE"
+
+# MaxScale user credentials
+maxscale_user = "CHOOSE A MAXSCALE USERNAME HERE"
+maxscale_pass = "SET YOUR MAXSCALE USER PASSWORD HERE"
+
+# Replication user credentials
+repli_user = "CHOOSE A REPLICA USERNAME HERE"
+repli_pass = "SET YOUR REPLICA USER PASSWORD HERE"
+
+# Columnstore utility user credentials
+cej_user = "CHOOSE A COLUMNSTORE UTILITY USERNAME HERE"
+cej_pass = "SET YOUR COLUMNSTORE UTILITY USER PASSWORD HERE"
+
+######## Cluster Size
+
+# Number of Columnstore nodes
+num_columnstore_nodes = 3
+
+# Number of MaxScale instances
+num_maxscale_instances = 2
+
+######## MariaDB Versions
+
+mariadb_version = "11.4"
+maxscale_version = "latest"
+
+######## AWS CONFIGURATION
+# Possible Authentication Combinations (leave unused variables = "")
+# 1) aws_access_key + aws_secret_key
+# 2) aws_access_key + aws_secret_key + aws_session_token
+# 3) aws_profile
+aws_access_key = ""
+aws_secret_key = ""
+aws_session_token = ""
+aws_profile = ""
+
+key_pair_name = "YOUR AWS KEY PAIR NAME HERE"
+ssh_key_file = "/PATH/TO/KEY/FILE.PEM"
+
+# aws_region will influence aws_vpc, aws_subnet, aws_zone & aws_ami
+aws_region = "us-west-2"
+aws_zone = "us-west-2a"
+
+# Confirm your VPC exists in aws_region chosen
+aws_vpc = "YOUR AWS VPC ID HERE"
+
+# Confirm your subnet exists in aws_vpc chosen
+aws_subnet = "YOUR AWS SUBNET ID HERE"
+
+######## AWS EC2 Options
+
+# AMI's are specific to regions
+aws_ami = "ami-0faa73a0256c330e9"
+
+security_group_name = "mcs_traffic"
+aws_mariadb_instance_size = "c6a.8xlarge"
+aws_maxscale_instance_size = "c6a.large"
+
+# Number of GB for EBS root storage on columnstore nodes
+columnstore_node_root_block_size = 1000
+
+# Number of GB for EBS root storage on maxscale nodes
+maxscale_node_root_block_size = 100
+
+# Prefix of the cluster to standup - Any Name You Want
+deployment_prefix = "testing"
+
+# Additional tags to apply to resources
+additional_tags = {
+  description = "testing columnstore"
+}
+
+# S3 Configuration
+s3_domain = "amazonaws.com"
+s3_ssl_disable = false
+s3_use_http = false
+
+######## Optional Install Options
+
+reboot = true
+
+# Optional - Requires "mariadb_rpms_path" to be defined
+# Arguments for cs_package_manager to auto download rpms
+cs_package_manager_custom_version = ""
+
+# The path mariadb and columnstore rpms are preloaded to after terraform apply --auto-approve, but before running ansible
+mariadb_rpms_path = ""

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Open a terminal window and clone the repository:
 
 1.  `git clone https://github.com/mariadb-corporation/columnstore-ansible.git`
 2.  `cd` into the newly cloned folder
-3.  `cp .tfvars.sample .tfvars` This file contains the values for the variables used in the Terraform configuration. You can use this file as a template to create your own `.tfvars` file.
-4.  Edit `.tfvars` and supply your own variable values. See `variables.tf` for variable descriptions.
+3.  `cp .tfvars.sample terraform.tfvars` This file contains the values for the variables used in the Terraform configuration.
+4.  Edit `terraform.tfvars` and supply your own variable values. See `variables.tf` for variable descriptions.
 5.  `terraform init`
-6.  `terraform plan -var-file=".tfvars"` (Optional)
-7.  `terraform apply -var-file=".tfvars" --auto-approve`
+6.  `terraform plan` (Optional)
+7.  `terraform apply --auto-approve`
 8.  `ansible-playbook provision.yml`
 
 Further information can be found on our [official deployment guide](https://mariadb.com/docs/deploy/enterprise-multi-columnstore/).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a [Terraform](https://www.terraform.io/) and [Ansible](https://www.ansib
 *   [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-with-pip) *<sup>‡</sup>*
 *   [MariaDB Enterprise Token](https://customers.mariadb.com/downloads/token/)
 
-*<sup>†</sup> Requires Terraform v0.14.4 or above.*  
+*<sup>†</sup> Requires Terraform v0.14.4 or above.*
 *<sup>‡</sup> Requires Full Ansible 2.10.5 or above. (Not Ansible-Core)*
 
 ## Instructions:
@@ -30,11 +30,12 @@ Open a terminal window and clone the repository:
 
 1.  `git clone https://github.com/mariadb-corporation/columnstore-ansible.git`
 2.  `cd` into the newly cloned folder
-3.  Edit [variables.tf](variables.tf) and supply your own variables.
-4.  `terraform init`
-5.  `terraform plan` (Optional)
-6.  `terraform apply --auto-approve`
-7.  `ansible-playbook provision.yml`
+3.  `cp .tfvars.sample .tfvars` This file contains the values for the variables used in the Terraform configuration. You can use this file as a template to create your own `.tfvars` file.
+4.  Edit `.tfvars` and supply your own variable values. See `variables.tf` for variable descriptions.
+5.  `terraform init`
+6.  `terraform plan -var-file=".tfvars"` (Optional)
+7.  `terraform apply -var-file=".tfvars" --auto-approve`
+8.  `ansible-playbook provision.yml`
 
 Further information can be found on our [official deployment guide](https://mariadb.com/docs/deploy/enterprise-multi-columnstore/).
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,9 +10,24 @@ output "ansible_config" {
   value = local_file.AnsibleConfig.filename
 }
 
+output "columnstore_nodes" {
+  description = "Details of the columnstore nodes"
+  value = local.columnstore_nodes
+}
+
+output "maxscale_nodes" {
+  description = "Details of the maxscale nodes"
+  value = local.maxscale_nodes
+}
+
+output "ssh_key_file" {
+  description = "Path to SSH key file"
+  value = var.ssh_key_file
+}
+
 locals {
   columnstore_nodes = [
-    for i in range(0, length(aws_instance.columnstore_node)) : 
+    for i in range(0, length(aws_instance.columnstore_node)) :
     {
       name        = "mcs${i+1}"
       public_dns  = aws_instance.columnstore_node[i].public_dns
@@ -23,7 +38,7 @@ locals {
   ]
 
   maxscale_nodes = [
-    for i in range(0, length(aws_instance.maxscale_instance)) : 
+    for i in range(0, length(aws_instance.maxscale_instance)) :
     {
       name        = "mx${i+1}"
       public_dns  = aws_instance.maxscale_instance[i].public_dns

--- a/variables.tf
+++ b/variables.tf
@@ -2,8 +2,6 @@
 ########
 ########  * VPCs
 ########  * Programmatic Access
-########
-######## Grab your enterprise token from the MariaDB website (https://customers.mariadb.com/downloads/token/).
 
 ######## EDIT THESE ITEMS
 
@@ -15,59 +13,70 @@ variable "use_s3" {
 
 variable "mariadb_enterprise_token" {
   type    = string
-  default = "YOUR MARIADB ENTERPRISE TOKEN HERE"
+  description = "MariaDB Enterprise Token (https://customers.mariadb.com/downloads/token/)"
+  nullable = false
 }
 
 variable "cmapi_key" {
   type    = string
-  default = "CREATE A COLUMNSTORE API KEY HERE - ANY RANDOM STRING"
+  description = "Columnstore API Key (any random string)"
+  nullable = false
 }
 
 variable "pcs_pass" {
   type    = string
-  default = "SET PCS CLUSTER PASSWORD HERE - ANY RANDOM STRING"
+  description = "PCS Cluster Password (any random string)"
+  nullable = false
 }
 
 ######## DATABASE CREDENTIALS
 
 variable "admin_user" {
   type    = string
-  default = "CHOOSE A MARIADB ADMIN USERNAME HERE"
+  description = "MariaDB Admin Username"
+  nullable = false
 }
 
 variable "admin_pass" {
   type    = string
-  default = "SET YOUR MARIADB ADMIN USER PASSWORD HERE"
+  description = "MariaDB Admin Password (any random string)"
+  nullable = false
 }
 
 variable "maxscale_user" {
   type    = string
-  default = "CHOOSE A MAXSCALE USERNAME HERE"
+  description = "MaxScale Username"
+  nullable = false
 }
 
 variable "maxscale_pass" {
   type    = string
-  default = "SET YOUR MAXSCALE USER PASSWORD HERE"
+  description = "MaxScale Password (any random string)"
+  nullable = false
 }
 
 variable "repli_user" {
   type    = string
-  default = "CHOOSE A REPLICA USERNAME HERE"
+  description = "Replica Username"
+  nullable = false
 }
 
 variable "repli_pass" {
   type    = string
-  default = "SET YOUR REPLICA USER PASSWORD HERE"
+  description = "Replica Password (any random string)"
+  nullable = false
 }
 
 variable "cej_user" {
   type    = string
-  default = "CHOOSE A COLUMNSTORE UTILITY USERNAME HERE"
+  description = "Columnstore Utility Username"
+  nullable = false
 }
 
 variable "cej_pass" {
   type    = string
-  default = "SET YOUR COLUMNSTORE UTILITY USER PASSWORD HERE"
+  description = "Columnstore Utility Password (any random string)"
+  nullable = false
 }
 
 ######## Cluster Size
@@ -88,15 +97,17 @@ variable "num_maxscale_instances" {
 
 variable "mariadb_version" {
   type    = string
+  description = "MariaDB Server Version"
   default = "11.4"
 }
 
 variable "maxscale_version" {
   type    = string
+  description = "MaxScale Version"
   default = "latest"
 }
 
-######## AWS CONFIGURATION 
+######## AWS CONFIGURATION
 # Possible Authentication Combinations (leave unused variables = "")
 # 1) aws_access_key + aws_secret_key
 # 2) aws_access_key + aws_secret_key + aws_session_token
@@ -104,62 +115,71 @@ variable "maxscale_version" {
 
 variable "aws_access_key" {
   type    = string
-  default = "YOUR AWS ACCESS KEY HERE"
+  description = "AWS Access Key"
+  default = ""
 }
 
 variable "aws_secret_key" {
   type    = string
-  default = "YOUR AWS SECRET KEY HERE"
+  description = "AWS Secret Key"
+  default = ""
 }
 
 variable "aws_session_token" {
   type    = string
-  default = "YOUR AWS SESSION TOKEN HERE"
+  description = "AWS Session Token"
+  default = ""
 }
 
 variable "aws_profile" {
   type    = string
-  default = "YOUR AWS PROFILE NAME KEY HERE"
+  description = "AWS Profile Name"
+  default = ""
 }
 
 variable "key_pair_name" {
   type    = string
-  default = "YOUR AWS KEY PAIR NAME HERE"
+  description = "AWS Key Pair Name"
+  nullable = false
 }
 
 variable "ssh_key_file" {
   type    = string
-  default = "/PATH/TO/KEY/FILE.PEM"
+  description = "Path to SSH key file"
+  nullable = false
 }
 
-# aws_region will influence aws_vpc, aws_subnet, aws_zone & aws_ami
 variable "aws_region" {
   type    = string
+  description = "AWS Region, will influence aws_vpc, aws_subnet, aws_zone & aws_ami"
   default = "us-west-2"
 }
 
 variable "aws_zone" {
   type    = string
+  description = "AWS Zone"
   default = "us-west-2a"
 }
 
 # Confirm your VPC exists in aws_region choosen
 variable "aws_vpc" {
   type    = string
-  default = "YOUR AWS VPC ID HERE"
+  description = "AWS VPC ID"
+  nullable = false
 }
 
 # Confirm your subnet exists in aws_vpc choosen
 variable "aws_subnet" {
   type    = string
-  default = "YOUR AWS SUBNET ID HERE"
+  description = "AWS Subnet ID"
+  nullable = false
 }
 
-######## AWS EC2 Options 
+######## AWS EC2 Options
 
-# AMI's are specific to regions
 variable "aws_ami" {
   type    = string
+  description = "AWS AMI ID, AMI's are specific to regions"
   default = "ami-0faa73a0256c330e9"
 }
 
@@ -227,7 +247,7 @@ variable "reboot" {
   default = true
 }
 
-# Optional - Requires "mariadb_rpms_path" to be defined - Argumemts for cs_package_manager to auto download rpms 
+# Optional - Requires "mariadb_rpms_path" to be defined - Arguments for cs_package_manager to auto download rpms
 variable "cs_package_manager_custom_version" {
   type    = string
   default = ""


### PR DESCRIPTION
• Variable values are now read from .tfvars file instead of variables.tf. This simplifies the Git workflow by making merges easier and eliminating the risk of accidentally committing secrets to variables.tf. It also makes programmatic usage simpler, since filling out a key-value .tfvars file is much easier than editing variables.tf directly.

• Also added host information and the SSH key file path to the outputs.