### PR TITLE
Ask user about number of instances (columnstore and maxscale) and the EBS volume size

### DIFF
--- a/kickstart.sh
+++ b/kickstart.sh
@@ -888,7 +888,12 @@ choose_distro
 
 check_or_choose_vpc_and_sg
 
+propose_change_value "num_columnstore_nodes" false "Number of ColumnStore nodes in the cluster"
+propose_change_value "num_maxscale_instances" false "Number of MaxScale nodes in the cluster"
+
 propose_change_value "aws_mariadb_instance_size"
+
+propose_change_value "columnstore_node_root_block_size" false "Number of GB for EBS root storage on columnstore nodes"
 
 handle_additional_tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -203,7 +203,7 @@ variable "aws_maxscale_instance_size" {
 variable "columnstore_node_root_block_size" {
   description = "Number of GB for EBS root storage on columnstore nodes"
   type        = number
-  default     = 1000
+  default     = 200
 }
 
 variable "maxscale_node_root_block_size" {


### PR DESCRIPTION
(turns out, 1TB default size of every columnstore host costs us a lot)