### PR TITLE
Various updates

### DIFF
--- a/.tfvars.sample
+++ b/.tfvars.sample
@@ -102,6 +102,8 @@ cs_package_manager_custom_version = ""
 # The path mariadb and columnstore rpms are preloaded to after terraform apply --auto-approve, but before running ansible
 mariadb_rpms_path = ""
 
+dev_drone_key = ""
+
 create_shared_efs = false
 shared_efs_include_dev_host = false
 shared_efs_mount_point = "/shared"

--- a/includes/cluster.yml
+++ b/includes/cluster.yml
@@ -162,26 +162,26 @@
 
   tasks:
 
-  # - name: "Fetch existing nodes in the cluster"
-  #   uri:
-  #     url: "https://{{ hostvars['mcs1'].ansible_host }}:8640/cmapi/0.4.0/cluster/status"
-  #     method: GET
-  #     headers:
-  #       Content-Type: application/json
-  #       x-api-key: "{{ api_key }}"
-  #     validate_certs: no
-  #     return_content: yes
-  #     status_code: 200
-  #   register: cluster_info
+  - name: "Fetch existing nodes in the cluster"
+    uri:
+      url: "https://{{ hostvars['mcs1'].ansible_host }}:8640/cmapi/0.4.0/cluster/status"
+      method: GET
+      headers:
+        Content-Type: application/json
+        x-api-key: "{{ api_key }}"
+      validate_certs: no
+      return_content: yes
+      status_code: 200
+    register: cluster_info
 
-  # - name: "Debug: Print existing nodes in the cluster"
-  #   debug:
-  #     msg: "{{ cluster_info.json }}"
+  - name: "Debug: Print existing nodes in the cluster"
+    debug:
+      msg: "{{ cluster_info.json }}"
 
-  # - name: "Remove existing nodes from the cluster"
-  #   shell: mcs cluster node remove --node {{ item.key }}
-  #   with_dict: "{{ cluster_info.json }}"
-  #   when: cluster_info.json['num_nodes'] | int > 0
+  - name: "Remove existing nodes from the cluster"
+    shell: mcs cluster node remove --node {{ item.key }}
+    with_dict: "{{ cluster_info.json }}"
+    when: cluster_info.json['num_nodes'] | int > 0
 
   - name: "Adding Nodes To ColumnStore Cluster"
     uri:

--- a/includes/dev_utils.yml
+++ b/includes/dev_utils.yml
@@ -38,7 +38,7 @@
           fi
 
           key_file="{{ ssh_key_file }}"
-          user="{{ os_user }}"
+          user="{{ hostvars[groups['primary'][0]].primary_os_user }}"
 
           if [ -z "$1" ]; then
               ssh -i "$key_file" "$user@$ip"

--- a/includes/install_rpms.yml
+++ b/includes/install_rpms.yml
@@ -47,7 +47,7 @@
   tasks:
 
   - name: "Download MariaDB RPMs using cs_package_manager script"
-    command: bash {{ mariadb_rpms_path }}/cs_package_manager.sh {{ cs_package_manager_custom_version }} --directory {{ mariadb_rpms_path }} 
+    command: bash {{ mariadb_rpms_path }}/cs_package_manager.sh download {{ cs_package_manager_custom_version }} -d {{ mariadb_rpms_path }}
     register: cs_package_manager_output
     when: cs_package_manager_custom_version is defined and cs_package_manager_custom_version != "" and cs_package_manager_custom_version is not none
 

--- a/includes/install_rpms.yml
+++ b/includes/install_rpms.yml
@@ -14,7 +14,7 @@
       path: "{{ mariadb_rpms_path }}"
       state: directory
       mode: '0755'
-      
+
   - name: "Check if MariaDB RPMs directory exists"
     stat:
       path: "{{ mariadb_rpms_path }}"
@@ -43,11 +43,14 @@
   vars_files:
     - '../inventory/group_vars/distro/{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }}.yml'
     - '../inventory/group_vars/all.yml'
-    
+
   tasks:
 
   - name: "Download MariaDB RPMs using cs_package_manager script"
-    command: bash {{ mariadb_rpms_path }}/cs_package_manager.sh download {{ cs_package_manager_custom_version }} -d {{ mariadb_rpms_path }}
+    command: >-
+      bash {{ mariadb_rpms_path }}/cs_package_manager.sh download {{ cs_package_manager_custom_version }}
+      -d {{ mariadb_rpms_path }}
+      {% if dev_drone_key is defined and dev_drone_key != "" %}-dev {{ dev_drone_key }}{% endif %}
     register: cs_package_manager_output
     when: cs_package_manager_custom_version is defined and cs_package_manager_custom_version != "" and cs_package_manager_custom_version is not none
 
@@ -261,7 +264,7 @@
   - name: "Debug list of RPM or DEB file paths found"
     debug:
       msg: "{{ rpm_files.files | map(attribute='path') | list }}"
- 
+
   - name: "Installing MariaDB RPMs from directory for maxscale"
     yum:
       name: "{{ rpm_files.files | map(attribute='path') | join(',') }}"

--- a/includes/prepare.yml
+++ b/includes/prepare.yml
@@ -6,14 +6,14 @@
   vars_files:
     - '../inventory/group_vars/all.yml'
     - '../inventory/group_vars/distro/{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }}.yml'
-  
+
   pre_tasks:
 
   - name: "Check instance type"
     set_fact:
       mariadb_is_metal: "{{ aws_mariadb_instance_size is search('\\.metal$') }}"
       maxscale_is_metal: "{{ aws_maxscale_instance_size is search('\\.metal$') }}"
-  
+
   tasks:
 
   - name: "Scanning For Running Services"
@@ -52,7 +52,7 @@
       name: '*'
       state: latest
       update_cache: yes
-  
+
   - name: "Set reboot to false if mariadb_is_metal or maxscale_is_metal is true"
     set_fact:
       reboot: false
@@ -142,3 +142,13 @@
       name: '{{ mariadb_libs }}'
       state: absent
     when: ansible_distribution|lower + ansible_distribution_major_version == "centos7"
+
+- hosts: "primary"
+  become: yes
+  become_user: root
+  vars_files:
+    - '../inventory/group_vars/distro/{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }}.yml'
+
+  tasks:
+    - set_fact:
+        primary_os_user: "{{ os_user }}"

--- a/inventory/group_vars/distro/debian12.yml
+++ b/inventory/group_vars/distro/debian12.yml
@@ -1,0 +1,32 @@
+---
+
+awscli: awscli
+boto: python3-boto3
+columnstore_cnf: /etc/mysql/mariadb.conf.d/columnstore.cnf
+gcc: gcc
+git: git
+gluster_server: glusterfs-server
+htop: htop
+jemalloc: libjemalloc2
+jq: jq
+mariadb_backup: mariadb-backup
+mariadb_client: mariadb-client
+mariadb_columnstore: mariadb-plugin-columnstore
+mariadb_columnstore_cmapi: mariadb-columnstore-cmapi
+mariadb_repo: /etc/apt/sources.list.d/mariadb.list
+mariadb_server: mariadb-server
+mariadb_socket: /run/mysqld/mysqld.sock
+maxscale: maxscale-enterprise
+mlocate: plocate
+nano: nano
+nfs_utils: nfs-client
+python_dev: python3-devмpre_task: apt autoremove --purge && apt clean && apt -y install python3
+python_mysql: python3-mysqldb
+python_requests: python3-requests
+server_cnf: /etc/mysql/mariadb.conf.d/50-server.cnf
+storagemanager_cnf: /etc/columnstore/storagemanager.cnf
+tar: tar
+unzip: unzip
+user: mariadb
+wget: wget
+os_user: admin

--- a/inventory/group_vars/distro/debian12.yml
+++ b/inventory/group_vars/distro/debian12.yml
@@ -20,7 +20,8 @@ maxscale: maxscale-enterprise
 mlocate: plocate
 nano: nano
 nfs_utils: nfs-client
-python_dev: python3-devмpre_task: apt autoremove --purge && apt clean && apt -y install python3
+python_dev: python3-dev
+pre_task: apt autoremove --purge && apt clean && apt -y install python3
 python_mysql: python3-mysqldb
 python_requests: python3-requests
 server_cnf: /etc/mysql/mariadb.conf.d/50-server.cnf

--- a/kickstart.sh
+++ b/kickstart.sh
@@ -599,15 +599,6 @@ choose_or_create_vpc_and_sg() {
 
     set_var_value "aws_subnet" "$subnet_id"
 
-    # Ensure the chosen/created subnet is public
-    if [ "$(is_subnet_public "$subnet_id")" != "public" ]; then
-        echo "Subnet $subnet_id is not public. Making it public..."
-        make_subnet_public "$subnet_id"
-        echo "Subnet $subnet_id is now public."
-    else
-        echo "Subnet $subnet_id is already public."
-    fi
-
     echo ""
 }
 
@@ -986,6 +977,17 @@ echo ""
 choose_distro
 
 check_or_choose_vpc_and_sg
+# Ensure the subnet is public
+final_subnet_id=$(get_current_var_value "aws_subnet")
+if [ -n "$final_subnet_id" ]; then
+    if [ "$(is_subnet_public "$final_subnet_id")" != "public" ]; then
+        echo "Subnet $final_subnet_id is not public. Making it public..."
+        make_subnet_public "$final_subnet_id"
+        echo "Subnet $final_subnet_id is now public."
+    else
+        echo "Subnet $final_subnet_id is already public."
+    fi
+fi
 
 propose_change_value "num_columnstore_nodes" false "Number of ColumnStore nodes in the cluster"
 propose_change_value "num_maxscale_instances" false "Number of MaxScale nodes in the cluster"

--- a/kickstart.sh
+++ b/kickstart.sh
@@ -375,11 +375,11 @@ select_or_create_aws_profile() {
     if [ -n "$current_session_token" ]; then
         local masked_token="${current_session_token:0:3}***${current_session_token: -3}"
         echo "An AWS session token is currently set: $masked_token"
-        read -p "Do you want to change or remove the AWS session token? [y/N]: " set_token
+        set_token=$(ask_boolean "change_aws_session_token" "Do you want to change or remove the AWS session token?" "false")
     else
         echo "Some AWS authentication methods (like MFA or SSO) require a session token."
         echo "If you are using temporary credentials, you may need to set this."
-        read -p "Do you want to set an AWS session token? [y/N]: " set_token
+        set_token=$(ask_boolean "set_aws_session_token" "Do you want to set an AWS session token?" "false")
     fi
     if [[ "$set_token" =~ ^[Yy]$ ]]; then
         read -p "Enter AWS session token (leave blank to unset): " session_token
@@ -549,7 +549,7 @@ check_or_choose_aws_key_pair() {
         echo "  key_pair_name = $current_key_pair"
         echo "  ssh_key_file  = $current_key_file"
 
-        read -p "Do you want to change it? [y/N]: " change_keys
+        change_keys=$(ask_boolean "change_aws_key_pair" "Do you want to change it?" "false")
         if [[ ! "$change_keys" =~ ^[Yy]$ ]]; then
             echo "Keeping current key pair."
             echo ""
@@ -1024,6 +1024,9 @@ echo ""
 note "The 'deployment_prefix' variable is used to uniquely identify your cluster resources."
 note "The default prefix 'testing' can cause conflicts with other clusters if not changed."
 propose_change_value "deployment_prefix" false "Enter a unique prefix for this deployment"
+
+propose_change_value "dev_drone_key" false "Enter CI bucket name if you want to be able to install dev builds"
+echo ""
 
 handle_additional_tags
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -90,6 +90,7 @@ resource "local_file" "AnsibleVariables" {
       mariadb_has_nvme         = can(regex("d\\.metal", var.aws_mariadb_instance_size)) ? true : false,
       mariadb_rpms_path        = var.mariadb_rpms_path,
       cs_package_manager_custom_version = var.cs_package_manager_custom_version,
+      dev_drone_key            = var.dev_drone_key,
       reboot                   = var.reboot,
       create_shared_efs        = var.create_shared_efs,
       shared_efs_volume_id     = var.create_shared_efs ? aws_efs_file_system.shared_efs[0].id : "",

--- a/provision.yml
+++ b/provision.yml
@@ -30,6 +30,9 @@
 - name: "Preparing The Servers"
   import_playbook: includes/prepare.yml
 
+- name: "Dev support utils"
+  import_playbook: includes/dev_utils.yml
+
 # - name: "Setting Up GFS2"
 #   import_playbook: includes/gfs2.yml
 #   when: use_s3
@@ -58,6 +61,3 @@
 - name: "Configuring shared EFS"
   import_playbook: includes/shared_efs.yml
   when: create_shared_efs | bool
-
-- name: "Dev support utils"
-  import_playbook: includes/dev_utils.yml

--- a/terraform_includes/all.tmpl
+++ b/terraform_includes/all.tmpl
@@ -48,6 +48,7 @@ pcs_pass: "${pcs_pass}"
 # Install Options
 mariadb_rpms_path: ${mariadb_rpms_path}
 cs_package_manager_custom_version: ${cs_package_manager_custom_version}
+dev_drone_key: ${dev_drone_key}
 reboot: ${reboot}
 
 # EFS Configuration

--- a/terraform_includes/create_user.sh
+++ b/terraform_includes/create_user.sh
@@ -4,6 +4,7 @@ USERNAME=mariadb
 GROUPNAME=mariadb
 ROCKY=/home/rocky
 CENTOS=/home/centos
+DEBIAN=/home/admin
 UBUNTU=/home/ubuntu
 ORACLE=/home/ec2-user
 NEW=/home/$USERNAME
@@ -24,6 +25,10 @@ fi
 
 if [ -d "$CENTOS" ]; then
     sudo cp $CENTOS/$KEYS $NEW/$KEYS
+fi
+
+if [ -d "$DEBIAN" ]; then
+    sudo cp $DEBIAN/$KEYS $NEW/$KEYS
 fi
 
 if [ -d "$UBUNTU" ]; then

--- a/variables.tf
+++ b/variables.tf
@@ -261,6 +261,12 @@ variable "mariadb_rpms_path" {
   default = ""
 }
 
+variable "dev_drone_key" {
+  type    = string
+  description = "Path prefix for dev builds"
+  default = ""
+}
+
 variable "create_shared_efs" {
   description = "Create a shared EFS volume for Columnstore nodes (optional)"
   type        = bool


### PR DESCRIPTION
- Added basic support of Debian 12
- Added support of the session tokens in kickstart.sh
- User can pass dev_drone_key in kickstart.sh and it will be passed to cs_package_manager.sh (if set)
- Make subnets public (so that they allocate public IPs and DNS)
- Fixed connect.sh generation when the OS in cluster is different from the OS on devhost
- Uncommented deletion of existing nodes in the cluster before adding nodes to allow re-provisioning